### PR TITLE
[PR] Fix build error - add qualifier

### DIFF
--- a/app/src/main/java/com/example/firstapp/di/Qualifier.kt
+++ b/app/src/main/java/com/example/firstapp/di/Qualifier.kt
@@ -1,0 +1,7 @@
+package com.example.firstapp.di
+
+import javax.inject.Qualifier
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class DefaultOkHttpClient

--- a/app/src/main/java/com/example/firstapp/fragment/build/network/NetworkModule.kt
+++ b/app/src/main/java/com/example/firstapp/fragment/build/network/NetworkModule.kt
@@ -1,6 +1,7 @@
 package com.example.firstapp.fragment.build.network
 
 import com.example.firstapp.data.api.BuildService
+import com.example.firstapp.di.DefaultOkHttpClient
 import com.skydoves.sandwich.coroutines.CoroutinesResponseCallAdapterFactory
 import dagger.Module
 import dagger.Provides
@@ -16,6 +17,7 @@ import javax.inject.Singleton
 class NetworkModule {
     @Provides
     @Singleton
+    @DefaultOkHttpClient
     fun provideOkHttpClient(): OkHttpClient {
         return OkHttpClient.Builder()
             .addInterceptor(HttpRequestInterceptor())
@@ -24,7 +26,7 @@ class NetworkModule {
 
     @Provides
     @Singleton
-    fun provideRetrofit(okHttpClient: OkHttpClient): Retrofit {
+    fun provideRetrofit(@DefaultOkHttpClient okHttpClient: OkHttpClient): Retrofit {
         return Retrofit.Builder()
             .client(okHttpClient)
             .baseUrl("http://ddragon.leagueoflegends.com/")

--- a/data/api/src/main/java/com/example/firstapp/data/api/di/ApiModule.kt
+++ b/data/api/src/main/java/com/example/firstapp/data/api/di/ApiModule.kt
@@ -30,6 +30,7 @@ class ApiModule {
 
     @Provides
     @Singleton
+    @ApiOkHttpClient
     fun provideOkHttpClient(): OkHttpClient {
         return OkHttpClient.Builder()
             .addInterceptor(ApiKeyInterceptor())
@@ -43,7 +44,7 @@ class ApiModule {
 
     @Provides
     @Singleton
-    fun provideSummonerApi(okHttpClient: OkHttpClient): SummonerApi {
+    fun provideSummonerApi(@ApiOkHttpClient okHttpClient: OkHttpClient): SummonerApi {
         return Retrofit.Builder()
             .baseUrl("https://kr.api.riotgames.com")
             .addConverterFactory(GsonConverterFactory.create())

--- a/data/api/src/main/java/com/example/firstapp/data/api/di/Qualifier.kt
+++ b/data/api/src/main/java/com/example/firstapp/data/api/di/Qualifier.kt
@@ -1,0 +1,7 @@
+package com.example.firstapp.data.api.di
+
+import javax.inject.Qualifier
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class ApiOkHttpClient


### PR DESCRIPTION
## Issue
- Build error 수정

## Detail
- Build 시 OkHttpClient 중복되어 hilt 오류 발생
- Qualifier 처리하여 해결
```
/Users/chris/dev/github/FirstApp/app/build/generated/hilt/component_sources/debug/com/example/firstapp/App_HiltComponents.java:166: error: [Dagger/DuplicateBindings] okhttp3.OkHttpClient is bound multiple times:
  public abstract static class SingletonC implements App_GeneratedInjector,
                         ^
      @Provides @Singleton @org.jetbrains.annotations.NotNull okhttp3.OkHttpClient com.example.firstapp.data.api.di.ApiModule.provideOkHttpClient()
      @Provides @Singleton @org.jetbrains.annotations.NotNull okhttp3.OkHttpClient com.example.firstapp.fragment.build.network.NetworkModule.provideOkHttpClient()
      okhttp3.OkHttpClient is injected at
          com.example.firstapp.fragment.build.network.NetworkModule.provideRetrofit(okHttpClient)
      retrofit2.Retrofit is injected at
          com.example.firstapp.fragment.build.network.NetworkModule.provideBuildService(retrofit)
      com.example.firstapp.data.api.BuildService is injected at
          com.example.firstapp.data.repository.di.MyRepositoryModule.provideBuildRepository(buildService, …)
      com.example.firstapp.data.repository.di.BuildRepository is injected at
          com.example.firstapp.model.BuildViewModel(buildRepository)
      com.example.firstapp.model.BuildViewModel is injected at
          com.example.firstapp.model.BuildViewModel_HiltModules.BindsModule.binds(vm)
      @dagger.hilt.android.internal.lifecycle.HiltViewModelMap java.util.Map<java.lang.String,javax.inject.Provider<androidx.lifecycle.ViewModel>> is requested at
          dagger.hilt.android.internal.lifecycle.HiltViewModelFactory.ViewModelFactoriesEntryPoint.getHiltViewModelMap() [com.example.firstapp.App_HiltComponents.SingletonC → com.example.firstapp.App_HiltComponents.ActivityRetainedC → com.example.firstapp.App_HiltComponents.ViewModelC]
```